### PR TITLE
Fix bug where clicking an untamed mob with node inspector causes a crash

### DIFF
--- a/inspect.lua
+++ b/inspect.lua
@@ -78,7 +78,11 @@ replacer.inspect = function(_, user, pointed_thing, mode, show_receipe)
 			end
 
 		end
-		text = text..' at '..minetest.pos_to_string(ref:getpos())
+		if ref:getpos() then
+			text = text..' at '..minetest.pos_to_string(ref:getpos())
+		else
+			text = text..' at an unknown location'
+		end
 		minetest.chat_send_player(name, text)
 		return nil
 	elseif (pointed_thing.type ~= 'node') then

--- a/inspect.lua
+++ b/inspect.lua
@@ -78,8 +78,8 @@ replacer.inspect = function(_, user, pointed_thing, mode, show_receipe)
 			end
 
 		end
-		if ref:getpos() then
-			text = text..' at '..minetest.pos_to_string(ref:getpos())
+		if ref:get_pos() then
+			text = text..' at '..minetest.pos_to_string(ref:get_pos())
 		else
 			text = text..' at an unknown location'
 		end


### PR DESCRIPTION
Closes BlockySurvival/issue-tracker#269